### PR TITLE
fix: 从 Chat 快照读取最终回复

### DIFF
--- a/.dsh-plugin/client.js
+++ b/.dsh-plugin/client.js
@@ -2678,17 +2678,17 @@ function useFillSessionArea(rootRef) {
     };
   }, [rootRef]);
 }
-function GalView({ useSession, inputActions, useScene, useHistory, useAssets, useFonts, useStore, actions, api }) {
+function GalView({ useSession, useChat, inputActions, useScene, useHistory, useAssets, useFonts, useStore, actions, api }) {
   const scene = useScene((s) => s);
   const history = useHistory((h) => h);
   const assets = useAssets((a) => a);
   const fonts = useFonts((f) => f);
   const readState = useStore((s) => s);
-  const nodes = useSession((s) => s.nodes);
-  const partial = useSession((s) => s.partial);
+  const nodes = useChat((s) => s.legacy.nodes);
+  const partial = useChat((s) => s.legacy.partial);
+  const runningCalls = useChat((s) => s.legacy.runningCalls);
   const running = useSession((s) => s.running);
   const blank = useSession((s) => s.blank);
-  const runningCalls = useSession((s) => s.runningCalls);
   const pending = useSession((s) => s.pending);
   const promptError = useSession((s) => s.promptError);
   const [mode, setMode] = (0, import_react3.useState)("game");

--- a/.dsh-plugin/client/GalView.jsx
+++ b/.dsh-plugin/client/GalView.jsx
@@ -1,5 +1,6 @@
 /** GAL 视窗顶层：模式切换 + 游戏模式（舞台/控制条/输入/历史/设置）+ 编辑模式。
- * 数据来源：useSession（会话快照 nodes/partial/running/blank）、useScene（场景）、
+ * 数据来源：useChat（对话快照 legacy nodes/partial/runningCalls）、
+ * useSession（会话生命周期 running/blank/pending/promptError）、useScene（场景）、
  * inputActions（发送走宿主输入机，与普通输入框同一管线）。
  */
 
@@ -152,19 +153,19 @@ function useFillSessionArea(rootRef) {
 
 /**
  * GAL 视窗组件（conversation.view 槽位条目）。
- * @param props - 槽位框架注入：sessionId/useSession/useInput/inputActions + inject 面的 useScene/useHistory/api。
+ * @param props - 槽位框架注入：sessionId/useSession/useChat/useInput/inputActions + inject 面的 useScene/useHistory/api。
  */
-export function GalView({ useSession, inputActions, useScene, useHistory, useAssets, useFonts, useStore, actions, api }) {
+export function GalView({ useSession, useChat, inputActions, useScene, useHistory, useAssets, useFonts, useStore, actions, api }) {
   const scene = useScene(s => s)
   const history = useHistory(h => h)
   const assets = useAssets(a => a)
   const fonts = useFonts(f => f)
   const readState = useStore(s => s)
-  const nodes = useSession(s => s.nodes)
-  const partial = useSession(s => s.partial)
+  const nodes = useChat(s => s.legacy.nodes)
+  const partial = useChat(s => s.legacy.partial)
+  const runningCalls = useChat(s => s.legacy.runningCalls)
   const running = useSession(s => s.running)
   const blank = useSession(s => s.blank)
-  const runningCalls = useSession(s => s.runningCalls)
   const pending = useSession(s => s.pending)
   const promptError = useSession(s => s.promptError)
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -108,23 +108,40 @@ async function pageTestPhase1() {
   const sessionState = {
     current: {
       sessionId: 'session-1',
-      nodes: [
-        { kind: 'user', seq: 1, content: [{ type: 'text', text: '你好' }], source: null },
-        { kind: 'assistant', seq: 2, turn: 1, step: 1, blocks: [{ kind: 'text', text: '……你终于来了。欢迎回来。' }] },
-      ],
-      partial: null,
       running: false,
       blank: false,
+      pending: [],
+      promptError: null,
+    },
+  }
+  const chatState = {
+    current: {
+      legacy: {
+        nodes: [
+          { kind: 'user', seq: 1, content: [{ type: 'text', text: '你好' }], source: null },
+          { kind: 'assistant', seq: 2, turn: 1, step: 1, blocks: [{ kind: 'text', text: '……你终于来了。欢迎回来。' }] },
+        ],
+        partial: null,
+        runningCalls: [],
+      },
     },
   }
   const sessionListeners = new Set()
+  const chatListeners = new Set()
   const sessionSource = {
     getSnapshot: () => sessionState.current,
     subscribe(fn) { sessionListeners.add(fn); return () => { sessionListeners.delete(fn) } },
   }
+  const chatSource = {
+    getSnapshot: () => chatState.current,
+    subscribe(fn) { chatListeners.add(fn); return () => { chatListeners.delete(fn) } },
+  }
   window.__setSession = next => {
-    sessionState.current = next
+    const { nodes = [], partial = null, runningCalls = [], ...session } = next
+    sessionState.current = session
+    chatState.current = { legacy: { nodes, partial, runningCalls } }
     for (const fn of [...sessionListeners]) fn()
+    for (const fn of [...chatListeners]) fn()
   }
 
   const React = window.React
@@ -142,6 +159,7 @@ async function pageTestPhase1() {
   const props = {
     sessionId: 'session-1',
     useSession: bindHook(sessionSource),
+    useChat: bindHook(chatSource),
     useInput: bindHook({ getSnapshot: () => ({ draft: '' }), subscribe: () => () => {} }),
     inputActions,
     useScene: bindHook(sceneSource),


### PR DESCRIPTION
## Problem

在当前 DSH 发布版 `0.1.2-rc.1` 的 `web` profile 中安装最新版 `gal-view 0.3.3` 后：

1. 打开已有会话并进入「GAL视窗」；
2. 发送消息后可以正常看到「思考中」状态；
3. 模型完成生成后，GAL 对话框不显示最终回复正文；
4. 切回 DSH 原生「对话」视图可以看到该回复，说明模型输出和会话数据本身正常。

这是插件与新版 DSH 前端数据契约不兼容导致的功能回归，而不是场景配置、素材或插件加载失败。

## Root cause

新版 DSH 将转录内容归属到 Chat target，并通过 `conversation.view` 的标准 `useChat` hook 暴露；兼容投影位于 `snapshot.legacy`。会话生命周期状态仍由 `useSession` 提供。

插件继续从 `useSession().nodes/partial/runningCalls` 读取正文，因此 `running` 等状态仍然有效，可以显示「思考中」，但模型定稿后的 assistant 节点不会进入 GAL 台词。

## Summary

- 从 `useChat().legacy` 读取 `nodes`、`partial` 和 `runningCalls`
- 保留 `useSession` 仅处理 `running`、`blank`、`pending` 和 `promptError` 等生命周期状态
- 不改变现有“思考中”和定稿后展示的交互
- 更新 smoke fixture，将 Session 与 Chat 数据源拆开，覆盖该兼容性回归
- 重新生成随插件发布的 `.dsh-plugin/client.js`

## Result

修复后，在 DSH `0.1.2-rc.1` 中：

- 「思考中」状态继续正常显示；
- 模型完成生成后，最终回复会正常进入 GAL 对话框；
- 原生对话、分页、打字机、工具状态和编辑模式行为保持不变。

## Test plan

- [x] `npm test`（73 tests passed）
- [x] `npm run build:client`
- [x] `npm run check:client`
- [x] `npm run smoke`（全部通过）
- [x] `git diff --check`

🤖 Generated with Claude Code